### PR TITLE
updated version of yt-dlp to fix functionality of net commands

### DIFF
--- a/BoomboxController/Other/Downloader.cs
+++ b/BoomboxController/Other/Downloader.cs
@@ -36,7 +36,7 @@ namespace BoomboxController
             Unpacking();
             if (!File.Exists(@$"BoomboxController\other\yt-dlp.exe"))
             {
-                Thread thread = new Thread(() => DownloadFiles(new Uri("https://github.com/yt-dlp/yt-dlp/releases/download/2025.01.26/yt-dlp.exe"), @"BoomboxController\other\yt-dlp.exe"));
+                Thread thread = new Thread(() => DownloadFiles(new Uri("https://github.com/yt-dlp/yt-dlp/releases/download/2025.11.12/yt-dlp.exe"), @"BoomboxController\other\yt-dlp.exe"));
                 thread.Start();
             }
             Thread.CurrentThread.Abort();


### PR DESCRIPTION
thanks for the mod. I updated the version of yt-dlp to [yt-dlp (11.12.25)](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.11.12) so it can properly handle youtube links.